### PR TITLE
Update stations_ogimet.R

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: climate
 Title: Interface to Download Meteorological (and Hydrological) Datasets
-Version: 1.1.1
+Version: 1.1.2
 Authors@R: c(person(given = "Bartosz",
            family = "Czernecki",
            role = c("aut", "cre"),

--- a/R/stations_ogimet.R
+++ b/R/stations_ogimet.R
@@ -71,8 +71,8 @@ stations_ogimet_bp = function(country = country, date = date, add_map = add_map)
   pattern = paste0(" (", gsub(x = country, pattern = "+", replacement = " ", fixed = TRUE))
   b22 = unlist(lapply(gregexpr(pattern = pattern, b1[[1]], fixed = TRUE), function(x) x[1]))
   
-  b1 = data.frame(str = b1[[1]], start = b21, stop = b22, stringsAsFactors = FALSE)
-  
+  b1 = data.frame(str = b1[[1]], start = b21, stop = b22 - 1, stringsAsFactors = FALSE) 
+
   res = substr(b1$str, b1$start, b1$stop)
   
   station_names = unlist(lapply(strsplit(res, " - "), function(x) x[length(x)]))


### PR DESCRIPTION
@bczernecki I've noticed that the station_names attribute has a space after the station name. This PR fixed this.

Current code:

``` r
library(climate)
pl = stations_ogimet(country = "Poland", add_map = FALSE)
#> [1] "http://ogimet.com/cgi-bin/gsynres?lang=en&state=Poland&osum=no&fmt=html&ord=REV&ano=2024&mes=05&day=10&hora=06&ndays=1&Send=send"
#> /tmp/RtmpHBypkH/fileb1c1e6030fd03
head(pl$station_names)
#> [1] "Petrobaltic Beta " "Kolobrzeg "        "Koszalin "        
#> [4] "Ustka "            "Leba "             "Lebork "
```

After changes:


``` r
library(climate)
pl = stations_ogimet(country = "Poland", add_map = FALSE)
#> [1] "http://ogimet.com/cgi-bin/gsynres?lang=en&state=Poland&osum=no&fmt=html&ord=REV&ano=2024&mes=05&day=10&hora=06&ndays=1&Send=send"
#> /tmp/RtmpBRdw9H/fileb1d0237284782
head(pl$station_names)
#> [1] "Petrobaltic Beta" "Kolobrzeg"        "Koszalin"         "Ustka"           
#> [5] "Leba"             "Lebork"
```

