### PR TITLE
fix: 95-duplicated-imgw-colnames

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -116,20 +116,9 @@ jobs:
           covr::codecov()
         shell: Rscript {0}
         
-      - name: Test coverage report
-        if: always()
-        run: |
-          covr_report <- covr::package_coverage(wrap = TRUE)
-          covr::report(x = covr_report, file = 'covr_report.html')
-          print(getwd())
-          print(dir())
-        shell: Rscript {0}
-
-      - name: Upload test coverage report
-        if: always()
-        uses: actions/upload-artifact@v3
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@54bcd8715eee62d40e33596ef5e8f0f48dbbccab # v4.1.0
         with:
-          name: ${{ runner.os }}-r${{ matrix.config.r }}-results
-          path: |
-            covr_report.html
-            lib
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: true
+        

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -110,17 +110,3 @@ jobs:
         with:
           name: ${{ runner.os }}-r${{ matrix.config.r }}-results
           path: check
-
-       # Run covr to generate the coverage report
-      - name: Generate test coverage
-        run: R -e 'covr::codecov()'
-
-      # Upload coverage report to Codecov
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: ./coverage.xml
-          flags: unittests
-          name: code-coverage-report
-          fail_ci_if_error: true

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -111,14 +111,16 @@ jobs:
           name: ${{ runner.os }}-r${{ matrix.config.r }}-results
           path: check
 
-      - name: Codecov
-        run: |
-          covr::codecov()
-        shell: Rscript {0}
-        
+       # Run covr to generate the coverage report
+      - name: Generate test coverage
+        run: R -e 'covr::codecov()'
+
+      # Upload coverage report to Codecov
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@54bcd8715eee62d40e33596ef5e8f0f48dbbccab # v4.1.0
+        uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage.xml
+          flags: unittests
+          name: code-coverage-report
           fail_ci_if_error: true
-        

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -1,0 +1,61 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+
+name: test-coverage.yaml
+
+permissions: read-all
+
+jobs:
+  test-coverage:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::covr, any::xml2
+          needs: coverage
+
+      - name: Test coverage
+        run: |
+          cov <- covr::package_coverage(
+            quiet = FALSE,
+            clean = FALSE,
+            install_path = file.path(normalizePath(Sys.getenv("RUNNER_TEMP"), winslash = "/"), "package")
+          )
+          covr::to_cobertura(cov)
+        shell: Rscript {0}
+
+      - uses: codecov/codecov-action@v4
+        with:
+          fail_ci_if_error: ${{ github.event_name != 'pull_request' && true || false }}
+          file: ./cobertura.xml
+          plugin: noop
+          disable_search: true
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: Show testthat output
+        if: always()
+        run: |
+          ## --------------------------------------------------------------------
+          find '${{ runner.temp }}/package' -name 'testthat.Rout*' -exec cat '{}' \; || true
+        shell: bash
+
+      - name: Upload test results
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-test-failures
+          path: ${{ runner.temp }}/package

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: climate
 Title: Interface to Download Meteorological (and Hydrological) Datasets
-Version: 1.2.0
+Version: 1.2.1
 Authors@R: c(person(given = "Bartosz",
            family = "Czernecki",
            role = c("aut", "cre"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # climate 1.2.1
 
 * Corrected duplicated column names for IMGW-PIB stations
+* Adjusted encoding changes and documentation updates in `meteo_imgw_telemetry_stations()`
 
 # climate 1.2.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# climate 1.2.1
+
+* Corrected duplicated column names for IMGW-PIB stations
+
 # climate 1.2.0
 
 * Corrected encoding problems for some of platforms where IMGW-PIB metadata were not parsed correctly

--- a/R/meteo_imgw_datastore.R
+++ b/R/meteo_imgw_datastore.R
@@ -35,7 +35,7 @@
 #' imgw_telemetry = meteo_imgw_datastore(year = 2022:2023,
 #'                                       parameters = "t2m",
 #'                                       stations = c("HALA GĄSIENICOWA",
-#'                                                    "DOLINA PIĘCIU STAWÓW"),
+#'                                                    "DOLINA 5 STAWÓW"),
 #'                                       coords = TRUE)
 #' }
 #'
@@ -84,7 +84,7 @@ meteo_imgw_datastore_bp = function(year,
   telemetry_stations$river = NULL
   
   if (!is.null(stations)) {
-    telemetry_stations = telemetry_stations[telemetry_stations$name %in% toupper(stations), ]
+    telemetry_stations = telemetry_stations[toupper(telemetry_stations$name) %in% toupper(stations), ]
   }
   
   urls = as.character(

--- a/R/meteo_shortening_imgw.R
+++ b/R/meteo_shortening_imgw.R
@@ -23,11 +23,16 @@ meteo_shortening_imgw = function(data, col_names = "short", remove_duplicates = 
   # removing duplicated column names:  (e.g. station's name)
   if (remove_duplicates == TRUE) {
     data = data[, !duplicated(colnames(data))]
-    
     # fix for merged station names with suffixes
     if (any(colnames(data) %in% c("Nazwa stacji.x", "Nazwa stacji.y"))) {
       data$`Nazwa stacji.y` = NULL
       colnames(data)[colnames(data) == "Nazwa stacji.x"] = "Nazwa stacji"
+    }
+    
+    # fix for mean air temperature which is stated sometimes in two files as:
+    # "Srednia dobowa temperatura[°C]" and "Srednia temperatura dobowa [°C]"
+    if (any(grepl(x = colnames(data), "Srednia dobowa temperatura"))) {
+      data[, which(grepl(x = colnames(data), "Srednia dobowa temperatura"))] = NULL
     }
   }
   

--- a/R/stations_meteo_imgw_telemetry.R
+++ b/R/stations_meteo_imgw_telemetry.R
@@ -14,10 +14,8 @@
 stations_meteo_imgw_telemetry = function() {
 
   url = "https://danepubliczne.imgw.pl/datastore/getfiledown/Arch/Telemetria/Meteo/kody_stacji.csv"
-  
   telemetry_stations = tryCatch(expr = suppressWarnings(
       read.csv(url,
-             fileEncoding = "CP1250",
              sep = ";",
              stringsAsFactors = FALSE)
       ), 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![R-CMD-check](https://github.com/bczernecki/climate/workflows/R-CMD-check/badge.svg)](https://github.com/bczernecki/climate/actions)
 [![HTML5 check](https://github.com/bczernecki/climate/actions/workflows/html5-check.yaml/badge.svg?branch=master)](https://github.com/bczernecki/climate/actions/workflows/html5-check.yaml)
 [![Codecov test
-coverage](https://codecov.io/gh/bczernecki/climate/branch/dev/graph/badge.svg)](https://app.codecov.io/gh/bczernecki/climate?branch=dev)
+coverage](https://codecov.io/gh/bczernecki/climate/branch/dev/graph/badge.svg)](https://app.codecov.io/gh/bczernecki/climate?branch=master)
 
 [![CRAN
 status](https://www.r-pkg.org/badges/version/climate)](https://cran.r-project.org/package=climate)

--- a/data-raw/parametry_skrot.csv
+++ b/data-raw/parametry_skrot.csv
@@ -58,7 +58,7 @@ Liczba dni z zamiecia sniezna wysoka,snowstorm_high_days,Days with high snowstor
 Liczba dni ze szronem,hoarfrost_days,Days with hoarfrost
 Liczba dni ze zmetnieniem,hazyness_days,Days with hazyness
 Maksymalna dobowa suma opadow [mm],rr_max_daily,Maximum daily preciptation [mm]
-Maksymalna temperatura dobowa [C],tmax_daily,Maximum daily air temperatury [C]
+Maksymalna temperatura dobowa [C],tmax_daily,Maximum daily air temperature [C]
 Maksymalna wysokosc pokrywy snieznej [cm],snowcover_max,Maximum daily snow cover [cm]
 Miesiac,mm,Month
 Miesieczna suma opadow [mm],rr_monthly,Total monthly precipitation [mm]

--- a/man/meteo_imgw_datastore.Rd
+++ b/man/meteo_imgw_datastore.Rd
@@ -58,7 +58,7 @@ Data from the IMGW automated (telemetry) systems are non validated by experts an
 imgw_telemetry = meteo_imgw_datastore(year = 2022:2023,
                                       parameters = "t2m",
                                       stations = c("HALA GĄSIENICOWA",
-                                                   "DOLINA PIĘCIU STAWÓW"),
+                                                   "DOLINA 5 STAWÓW"),
                                       coords = TRUE)
 }
 

--- a/tests/testthat/test-meteo_ogimet.R
+++ b/tests/testthat/test-meteo_ogimet.R
@@ -25,17 +25,17 @@ test_that("meteo_ogimet works!", {
   
   # check if January is going to be downloaded not other dates are downloaded by accident:
   x = meteo_ogimet(interval = "hourly", date = c("2019-01-01", "2019-01-05"),
-               station = 12001, coords = FALSE)
+               station = 12120, coords = FALSE)
   
-  if (is.data.frame(x) & nrow(df) > 0) {
+  if (is.data.frame(x) & nrow(x) > 0) {
     testthat::expect_equal(unique(format(x$Date, "%Y")), "2019")
   }
   
   # check precip_split on empty precipitation field
   petrobaltic = ogimet_hourly(station = 12001,
-                         date = c(as.Date("2019-01-01"), as.Date("2019-01-05")),
+                         date = c(as.Date("2020-01-01"), as.Date("2020-01-05")),
                          coords = TRUE, precip_split = TRUE)
-  if (is.data.frame(petrobaltic) & nrow(df) > 0) {
+  if (is.data.frame(petrobaltic) & nrow(petrobaltic) > 0) {
     testthat::expect_true(all(is.na(petrobaltic$pr12)))
   }
 


### PR DESCRIPTION
For some of IMGW-PIB datasets which is merged across two files colnames for the same variable have different labels thus require extra curation (i.e. `Srednia dobowa temperatura[°C]` and `Srednia temperatura dobowa [°C]`).