### PR TITLE
Detect all non-Polish locales in check_locale()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,9 @@
   repository that match the provided name(s) and return all available datasets for 
   those stations (e.g.entry "WARSZAWA" will also search for: "WARSZAWA-BIELANY", 
   "WARSZAWA-OKECIE", "WARSZAWA-OBSERWATORIUM", etc.)
+* `check_locale()` now detects any non-Polish locale instead of only two
+  hardcoded ones, so IMGW files read correctly under locales such as
+  `en_GB.UTF-8`
 
 
 

--- a/R/check_locale.R
+++ b/R/check_locale.R
@@ -1,18 +1,16 @@
 #' Check locale
 #'
-#' This is an extra check for some systems that make use of "C.UTF-8" or any
-#' iso-like encoding recognized as causing potential problems;
-#' The provided list of checked encoding cannot parse properly characters used
-#' in the Polish metservice's repository and therefore will be forced to
-#' use ASCII//TRANSLIT
+#' This is an extra check for systems whose locale cannot parse properly the
+#' characters used in the Polish metservice's repository. Any non-Polish locale
+#' is affected, so reading is forced to use ASCII//TRANSLIT in that case.
 #' @noRd
 #' @keywords internal
-#' @return 1 if the locale is not UTF-8, 0 otherwise
+#' @return 1 if the locale is not Polish, 0 otherwise
 
 check_locale = function() {
 
-  if (Sys.getlocale("LC_CTYPE") %in% c("C.UTF-8", "en_US.iso885915")) {
-    locale = Sys.getlocale("LC_CTYPE")
+  locale = Sys.getlocale("LC_CTYPE")
+  if (!grepl("^pl|^polish", locale, ignore.case = TRUE)) {
     message(paste0("    Your system locale is: ", locale, " which may cause trouble.
     Please consider changing it manually while working with climate, e.g.:
     Sys.setlocale(category = 'LC_ALL', locale = 'en_US.UTF-8') "))

--- a/tests/testthat/test-check_locale.R
+++ b/tests/testthat/test-check_locale.R
@@ -1,0 +1,12 @@
+test_that("check_locale flags non-Polish locales", {
+
+  old_locale = Sys.getlocale("LC_CTYPE")
+  on.exit(suppressWarnings(Sys.setlocale("LC_CTYPE", old_locale)), add = TRUE)
+
+  if (!is.na(suppressWarnings(Sys.setlocale("LC_CTYPE", "en_GB.UTF-8"))) &&
+      Sys.getlocale("LC_CTYPE") == "en_GB.UTF-8") {
+    expect_equal(suppressMessages(check_locale()), 1)
+  } else {
+    skip("en_GB.UTF-8 locale not available")
+  }
+})


### PR DESCRIPTION
Closes #124.

check_locale() only forced ASCII//TRANSLIT for two hardcoded locales (C.UTF-8 and en_US.iso885915), so other non-Polish locales like en_GB.UTF-8 slipped through and the IMGW files were read with the wrong encoding, failing later with a cryptic subscript-out-of-bounds error. This switches the check to detect any non-Polish locale instead of maintaining an incomplete blacklist, keeping pl_* and Windows Polish_* locales untouched. Added a regression test for a non-Polish locale.